### PR TITLE
Dynamically determine the whole libraryDependency instead of just version number

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,18 +6,16 @@ enablePlugins(ScalaJSPlugin)
 
 import Ordering.Implicits._
 
-libraryDependencies += {
-  if (VersionNumber(scalaJSVersion).numbers >= Seq(1L)) {
-    "org.scala-js" %%% "scalajs-dom" % "2.0.0"
-  } else {
-    "org.scala-js" %%% "scalajs-dom" % "1.2.0"
-  }
+if (VersionNumber(scalaJSVersion).numbers >= Seq(1L)) {
+  libraryDependencies += "org.scala-js" %%% "scalajs-dom" % "2.0.0"
+} else {
+  libraryDependencies += "org.scala-js" %%% "scalajs-dom" % "1.2.0"
 }
 
-libraryDependencies += "com.thoughtworks.binding" %%% "binding" % {
+libraryDependencies += {
   if (VersionNumber(scalaVersion.value).numbers >= Seq(2L, 13L)) {
-    "12.1.0"
+    "com.thoughtworks.binding" %%% "binding" % "12.1.0"
   } else {
-    "11.9.0"
+    "com.thoughtworks.binding" %%% "binding" % "11.9.0"
   }
 }


### PR DESCRIPTION
Hopefully this would help scala-steward's pattern matching